### PR TITLE
Allow protected memory to be shared across threads

### DIFF
--- a/src/mem.rs
+++ b/src/mem.rs
@@ -255,6 +255,19 @@ macro_rules! hardened_buffer {
                 }
             }
 
+            /// # Safety
+            /// It is safe to transfer ownership between threads because we have exclusive access to
+            /// the inner pointer.
+            /// As long as we respect rust borrowing rules, there is no way the internal pointer can be freed
+            /// more than once.
+            unsafe impl core::marker::Send for $name {}
+            /// # Safety
+            /// A read-only reference is safe to send across multiple threads because we have exclusive
+            /// access to the inner pointer.
+            /// As long as we respect rust borrowing rules, there is no way the internal pointer can be freed
+            /// more than once.
+            unsafe impl core::marker::Sync for $name {}
+
             impl Drop for $name {
                 fn drop(&mut self) {
                     // We do not use `require_init` here, as it must be called to initialise this


### PR DESCRIPTION
The `hardend_buffer` macro generates all keys and other important data that need to be protected. The underlying struct is based on a pointer, hence by default the `Send` and `Sync` marker traits are not implemented, making it impossible to share such important data between threads.

Given that each new type have exclusive access to its pointer, and given that no mutability is possible from a read-only reference, and for the same reasons why it is safe to `Deref` and `DerefMut` to a `[u8; $size]`, it is safe to share such a memory.

Sharing keys is especially useful for handling a master key. In my use case, I need to encrypt and decrypt different kind of data on disk, thus I generate a master key with `pbkdf::derive_key` and then generate further keys with `kdf::derive_key`. However, generating the master key on multiple threads is expensive and may be exploited for a Denial of Service attack, especially because I'd like to keep the security high and use the `MODERATE` recommendation for ops and mem.

Let me know what you think, and thank you for working on this library!